### PR TITLE
[🐸 Frogbot] Update version of org.apache.commons:commons-lang3 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.16.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.groovy</groupId>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2025-48924 | Not Covered | io.rest-assured:rest-assured:5.5.6-SNAPSHOT<br>io.rest-assured:json-path:5.5.6-SNAPSHOT<br>io.rest-assured:rest-assured-common:5.5.6-SNAPSHOT<br>io.rest-assured:scala-extensions:5.5.6-SNAPSHOT<br>io.rest-assured.examples:scalatra-webapp:5.5.6-SNAPSHOT<br>io.rest-assured.examples:scalatra-example:5.5.6-SNAPSHOT<br>io.rest-assured:scala-support:5.5.6-SNAPSHOT<br>io.rest-assured:xml-path:5.5.6-SNAPSHOT<br>io.rest-assured:kotlin-extensions:5.5.6-SNAPSHOT<br>io.rest-assured:spring-web-test-client:5.5.6-SNAPSHOT<br>io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT | org.apache.commons:commons-lang3 3.16.0 | [3.18.0] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | frogbot-new |
| **Watch Name:** | frogbot_w |
| **Contextual Analysis:** | Not Covered |
| **Direct Dependencies:** | io.rest-assured:rest-assured:5.5.6-SNAPSHOT, io.rest-assured:json-path:5.5.6-SNAPSHOT, io.rest-assured:rest-assured-common:5.5.6-SNAPSHOT, io.rest-assured:scala-extensions:5.5.6-SNAPSHOT, io.rest-assured.examples:scalatra-webapp:5.5.6-SNAPSHOT, io.rest-assured.examples:scalatra-example:5.5.6-SNAPSHOT, io.rest-assured:scala-support:5.5.6-SNAPSHOT, io.rest-assured:xml-path:5.5.6-SNAPSHOT, io.rest-assured:kotlin-extensions:5.5.6-SNAPSHOT, io.rest-assured:spring-web-test-client:5.5.6-SNAPSHOT, io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT |
| **Impacted Dependency:** | org.apache.commons:commons-lang3:3.16.0 |
| **Fixed Versions:** | [3.18.0] |
| **CVSS V3:** | 6.5 |

Uncontrolled Recursion vulnerability in Apache Commons Lang.

This issue affects Apache Commons Lang: Starting with commons-lang:commons-lang 2.0 to 2.6, and, from org.apache.commons:commons-lang3 3.0 before 3.18.0.

The methods ClassUtils.getClass(...) can throw StackOverflowError on very long inputs. Because an Error is usually not handled by applications and libraries, a 
StackOverflowError could cause an application to stop.

Users are recommended to upgrade to version 3.18.0, which fixes the issue.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
