### PR TITLE
[🐸 Frogbot] Update version of commons-io:commons-io to 2.14.0

### DIFF
--- a/modules/spring-web-test-client/pom.xml
+++ b/modules/spring-web-test-client/pom.xml
@@ -32,7 +32,7 @@
         <servlet-api.version>4.0.1</servlet-api.version>
         <spring.restdocs.version>2.0.2.RELEASE</spring.restdocs.version>
         <powermock-module-junit4.version>1.7.4</powermock-module-junit4.version>
-        <commons-io.version>2.8.0</commons-io.version>
+        <commons-io.version>2.14.0</commons-io.version>
         <org.skyscreamer>1.5.0</org.skyscreamer>
     </properties>
 


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![high (not applicable)](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/notApplicableHigh.png)<br>    High | CVE-2024-47554 | Not Applicable | commons-io:commons-io:2.8.0<br>io.rest-assured:rest-assured:5.5.6-SNAPSHOT<br>io.rest-assured:kotlin-extensions:5.5.6-SNAPSHOT<br>io.rest-assured:scala-extensions:5.5.6-SNAPSHOT<br>io.rest-assured:spring-web-test-client:5.5.6-SNAPSHOT<br>io.rest-assured.examples:scalatra-webapp:5.5.6-SNAPSHOT<br>io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT<br>io.rest-assured:scala-support:5.5.6-SNAPSHOT<br>io.rest-assured.examples:scalatra-example:5.5.6-SNAPSHOT | commons-io:commons-io 2.8.0 | [2.14.0] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | policy-sanity_maven_rest_assured_commit_partial_default-1754825139 |
| **Watch Name:** | watch-sanity_maven_rest_assured_commit_partial_default-1754825139 |
| **Jfrog Research Severity:** | <img src="https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/smallMedium.svg" alt=""/> Medium |
| **Contextual Analysis:** | Not Applicable |
| **Direct Dependencies:** | commons-io:commons-io:2.8.0, io.rest-assured:rest-assured:5.5.6-SNAPSHOT, io.rest-assured:kotlin-extensions:5.5.6-SNAPSHOT, io.rest-assured:scala-extensions:5.5.6-SNAPSHOT, io.rest-assured:spring-web-test-client:5.5.6-SNAPSHOT, io.rest-assured.examples:scalatra-webapp:5.5.6-SNAPSHOT, io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT, io.rest-assured:scala-support:5.5.6-SNAPSHOT, io.rest-assured.examples:scalatra-example:5.5.6-SNAPSHOT |
| **Impacted Dependency:** | commons-io:commons-io:2.8.0 |
| **Fixed Versions:** | [2.14.0] |
| **CVSS V3:** | 7.5 |

ReDoS in Apache Commons IO leads to denial of service when parsing crafted input with XMLStreamReader


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
